### PR TITLE
Sonarr monitoring addition

### DIFF
--- a/binary_sensors/sonarr_monitor.yaml
+++ b/binary_sensors/sonarr_monitor.yaml
@@ -3,4 +3,4 @@ name: Sonarr Monitor
 device_class: connectivity
 command: response=$(curl -LIk -m 3 http://172.16.0.2:8989 -o /dev/null -w "%{http_code}\n" -s); test "$response" -eq 200 && echo "ON" || echo "OFF"
 scan_interval: 60
-value_template: '{{ value }}'
+value_template: '{{value}}'


### PR DESCRIPTION
Addition of a binary sensor to monitor the status of Sonarr.
Part of additions for #1 